### PR TITLE
Added headers argument to tagger response object

### DIFF
--- a/tagger/routes.py
+++ b/tagger/routes.py
@@ -57,7 +57,8 @@ def sync():
         # Create generator for individual emails
         email_gen = msg.generate_emails(service, email_list)
 
-        return Response(msg.generate_tagged_emails(service, email_gen))
+        return Response(msg.generate_tagged_emails(service, email_gen),
+                        headers={"Content-Type": "application/json"})
 
     else:
         return "This functionality has not been created, yet."


### PR DESCRIPTION
Per A. Kawa request I added header's argument to the tagger response object so that the output is not interpreted as plaintext.